### PR TITLE
Fix warnings

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -102,3 +102,5 @@ coder: Abhishek Jaiantilal (abhishek.jaiantilal@colorado.edu). And suggestions/h
 contributor: raininja <daniel.mclellan@gmail.com>
 contributor: Richard Hull <rm_hull@yahoo.co.uk>
 contributor: andareed
+contributor: Alexander Riccio <test35965@gmail.com>
+

--- a/cpuinfo.c
+++ b/cpuinfo.c
@@ -141,7 +141,7 @@ void print_socket_information(struct cpu_socket_info* socket)
     for (i=0;i< socket->max_cpu ;i++) {
         assert(i < MAX_SK_PROCESSORS);
         if (socket->processor_num[i]!=-1) {
-            sprintf(socket_list,"%s%d,",socket_list,socket->processor_num[i]);
+            snprintf(socket_list, 200, "%s%d,",socket_list,socket->processor_num[i]);
         }
     }
     printf("Socket-%d [num of cpus %d physical %d logical %d] %s\n",socket->socket_num,socket->max_cpu,socket->num_physical_cores,socket->num_logical_cores,socket_list);

--- a/i7z.h
+++ b/i7z.h
@@ -166,6 +166,7 @@ void print_CPU_Heirarchy(struct cpu_heirarchy_info chi);
 int in_core_list(int ii,int* core_list);
 void Print_Version_Information();
 bool file_exists(char*);
+void call_system(const char* cmd);
 
 #define SET_ONLINE_ARRAY_MINUS1(online_cpus) {int iii;for(iii=0;iii<MAX_PROCESSORS;iii++) online_cpus[iii]=-1;}
 #define SET_ONLINE_ARRAY_PLUS1(online_cpus) {int iii;for(iii=0;iii<MAX_PROCESSORS;iii++) online_cpus[iii]=1;}

--- a/i7z_Dual_Socket.c
+++ b/i7z_Dual_Socket.c
@@ -186,6 +186,8 @@ void print_i7z_socket(struct cpu_socket_info socket_0, int printw_offset, int PL
         RETURN_IF_TRUE(online_cpus[0]==-1);
 
         int IA32_FIXED_CTR_CTL = 909;	//38D
+
+        //FIXME: why isn't this value actually used??
         int IA32_FIXED_CTR_CTL_Value = get_msr_value (CPU_NUM, IA32_FIXED_CTR_CTL, 63, 0, &error_indx);
         SET_IF_TRUE(error_indx,online_cpus[0],-1);
         RETURN_IF_TRUE(online_cpus[0]==-1);
@@ -661,6 +663,7 @@ void print_i7z ()
     //int *core_list, core_list_size_phy, core_list_size_log;
 
     //iterator
+    //FIXME: why isn't this value actually used??
     int i;
 
     //turbo_mode enabled/disabled flag
@@ -705,6 +708,7 @@ void print_i7z ()
     TURBO_MODE = turbo_status ();
 
     //Flags and other things about HT.
+    //FIXME: why isn't this value actually used??
     int HT_ON;
     char HT_ON_str[30];
 

--- a/i7z_Single_Socket.c
+++ b/i7z_Single_Socket.c
@@ -204,6 +204,7 @@ void print_i7z_socket_single(struct cpu_socket_info socket_0, int printw_offset,
         char string_ptr1[200], string_ptr2[200];
 
         int IA32_PERF_GLOBAL_CTRL = 911;	//38F
+        //FIXME: why isn't this value actually used??
         int IA32_PERF_GLOBAL_CTRL_Value;
         IA32_PERF_GLOBAL_CTRL_Value =	get_msr_value (CPU_NUM, IA32_PERF_GLOBAL_CTRL, 63, 0, &error_indx);
         SET_IF_TRUE(error_indx,online_cpus[0],-1);
@@ -211,6 +212,7 @@ void print_i7z_socket_single(struct cpu_socket_info socket_0, int printw_offset,
 
         int IA32_FIXED_CTR_CTL = 909;	//38D
         int IA32_FIXED_CTR_CTL_Value;
+        //FIXME: why isn't this value actually used??
         IA32_FIXED_CTR_CTL_Value = get_msr_value (CPU_NUM, IA32_FIXED_CTR_CTL, 63, 0, &error_indx);
         SET_IF_TRUE(error_indx,online_cpus[0],-1);
         RETURN_IF_TRUE(online_cpus[0]==-1);
@@ -662,6 +664,7 @@ void print_i7z_single ()
     //int *core_list, core_list_size_phy, core_list_size_log;
 
     //iterator
+    //FIXME: why isn't this value actually used??
     int i;
 
     //turbo_mode enabled/disabled flag
@@ -714,6 +717,7 @@ void print_i7z_single ()
 
     //Flags and other things about HT.
     int HT_ON;
+    //FIXME: why isn't this value actually used??
     char HT_ON_str[30];
 
     int kk_1 = 11;


### PR DESCRIPTION
I've said most everything in my commit message for de11b912297e7175834dc97aaba8cd9e03c3c75b

...but in short, when I went to build i7z from source to use it, gcc spat out several warnings, so I fixed them. I tried to keep the changes minimal to reduce code churn. I've also tweaked the string formatting where they weren't generating warnings, but a minimal change would be technically safer. I'm not sure how you feel about PRs, but hopefully this is fine.